### PR TITLE
fixed review-notice css

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -124,11 +124,6 @@ footer {
     display: flex;
     justify-content: center;
     align-items: center;
-}
-
-.review-notice h6 {
-    margin: 0;
     font-weight: 600;
-    text-align: center;
-    width: 100%;
+    height: 50px;
 }

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -22,7 +22,7 @@ def config_page(version):
     # Add review notice header
     st.markdown("""
     <div class="review-notice">
-        <h6 style="text-align: center; width: 100%; margin: 0;">This repository is under review for potential modification in compliance with Administration directives.</h6>
+        This repository is under review for potential modification in compliance with Administration directives.
     </div>
     """, unsafe_allow_html=True)
 


### PR DESCRIPTION
This pull request includes changes to the `css/dashboard.css` and `src/dashboard.py` files to modify the review notice styling and improve the layout.

Styling and layout improvements:

* [`css/dashboard.css`](diffhunk://#diff-0a8920a158dd3ffe98d205bc964eabfd5710e198d23c9aae56fe3e3343b9677eL127-R128): Removed the `.review-notice h6` styling block and adjusted the `footer` styling to include a fixed height of 50px.
* [`src/dashboard.py`](diffhunk://#diff-06135492c180d831917894055e5bb06ed9c4f31998a88b446abd432d50f6a4c7L25-R25): Simplified the review notice header by removing the `<h6>` tag and its associated inline styling.